### PR TITLE
Ajout d'un A/B Test Matamo sur la homepage

### DIFF
--- a/pilotage/templates/partials/home_section_accompagne.html
+++ b/pilotage/templates/partials/home_section_accompagne.html
@@ -23,7 +23,7 @@
                         </h3>
                     </div>
                     <div class="card-footer">
-                        <a href="{% url 'pilotage:tableaux_de_bord_prives' %}" class="btn btn-link stretched-link">Accéder à mes statistiques</a>
+                        <a href="{% url 'pilotage:tableaux_de_bord_prives' %}" class="btn btn-link stretched-link" data-matomo-category="statistiques" data-matomo-action="click" data-matomo-option="simplifier">Accéder à mes statistiques</a>
                     </div>
                 </div>
             </div>
@@ -41,7 +41,7 @@
                         <h3 class="mt-3 mb-0">Enrichir les instances locales de pilotage (dialogue de gestion, CTA, CTS, CDIAE…)</h3>
                     </div>
                     <div class="card-footer">
-                        <a href="{% url 'pilotage:tableaux_de_bord_prives' %}" class="btn btn-link stretched-link">Accéder à mes statistiques</a>
+                        <a href="{% url 'pilotage:tableaux_de_bord_prives' %}" class="btn btn-link stretched-link" data-matomo-category="statistiques" data-matomo-action="click" data-matomo-option="enrichir">Accéder à mes statistiques</a>
                     </div>
                 </div>
             </div>
@@ -55,7 +55,7 @@
                         <h3 class="mt-3 mb-0">Objectiver les situations et les échanges avec les partenaires</h3>
                     </div>
                     <div class="card-footer">
-                        <a href="{% url 'pilotage:tableaux_de_bord_prives' %}" class="btn btn-link stretched-link">Accéder à mes statistiques</a>
+                        <a href="{% url 'pilotage:tableaux_de_bord_prives' %}" class="btn btn-link stretched-link" data-matomo-category="statistiques" data-matomo-action="click" data-matomo-option="objectiver">Accéder à mes statistiques</a>
                     </div>
                 </div>
             </div>
@@ -69,7 +69,7 @@
                         <h3 class="mt-3 mb-0">Faciliter la réalisation et le suivi des plans d’actions</h3>
                     </div>
                     <div class="card-footer">
-                        <a href="{% url 'pilotage:tableaux_de_bord_prives' %}" class="btn btn-link stretched-link">Accéder à mes statistiques</a>
+                        <a href="{% url 'pilotage:tableaux_de_bord_prives' %}" class="btn btn-link stretched-link" data-matomo-category="statistiques" data-matomo-action="click" data-matomo-option="faciliter">Accéder à mes statistiques</a>
                     </div>
                 </div>
             </div>

--- a/pilotage/templates/partials/home_section_suggestion.html
+++ b/pilotage/templates/partials/home_section_suggestion.html
@@ -26,22 +26,3 @@
         </div>
     </div>
 </section>
-
-
-<script>
-    let inputContinuer = document.getElementById("input-continuer");
-    let btnContinuer = document.getElementById("btn-continuer");
-    let tallyUrl = "https://tally.so/r/3la8PB";
-
-    inputContinuer.addEventListener("keydown", function(e) {
-        if (inputContinuer.value.length > 1) {
-            btnContinuer.removeAttribute("disabled");
-        } else {
-            btnContinuer.setAttribute("disabled", "");
-        }
-    });
-
-    btnContinuer.addEventListener("click", function(e) {
-        window.open(tallyUrl + "?suggestion=" + inputContinuer.value);
-    });
-</script>

--- a/pilotage/templates/pilotage/home.html
+++ b/pilotage/templates/pilotage/home.html
@@ -37,11 +37,21 @@
 
     {% include 'partials/home_section_apercu.html' %}
 
-    {% include 'partials/home_section_comment.html' %}
+    <div id="original">
+        {% include 'partials/home_section_comment.html' %}
 
-    {% include 'partials/home_section_suggestion.html' %}
+        {% include 'partials/home_section_suggestion.html' %}
 
-    {% include 'partials/home_section_accompagne.html' %}
+        {% include 'partials/home_section_accompagne.html' %}
+    </div>
+
+    <div id="variationB" class="d-none">
+        {% include 'partials/home_section_accompagne.html' %}
+
+        {% include 'partials/home_section_suggestion.html' %}
+
+        {% include 'partials/home_section_comment.html' %}
+    </div>
 
     <section class="s-section mt-md-0 mb-md-7">
         <div class="s-section__container container container-max-lg">
@@ -66,4 +76,58 @@
 {% block js %}
     {{ block.super }}
     {% include 'partials/footer-scripts.html' with hasTracking=True %}
+
+    <script>
+        let inputContinuer = document.getElementById("input-continuer");
+        let btnContinuer = document.getElementById("btn-continuer");
+        let tallyUrl = "https://tally.so/r/3la8PB";
+
+        inputContinuer.addEventListener("keydown", function(e) {
+            if (inputContinuer.value.length > 1) {
+                btnContinuer.removeAttribute("disabled");
+            } else {
+                btnContinuer.setAttribute("disabled", "");
+            }
+        });
+
+        btnContinuer.addEventListener("click", function(e) {
+            window.open(tallyUrl + "?suggestion=" + inputContinuer.value);
+        });
+    </script>
+
+    <!-- Matomo A/B Test -->
+    <script type="text/javascript">
+        const original = document.getElementById("original");
+        const variationB = document.getElementById("variationB");
+
+        var _paq = _paq || [];
+        _paq.push(['AbTesting::create', {
+            name: 'QuelleVersionDeLaHomepage', // you can also use '7' (ID of the experiment) to hide the name
+            percentage: 100,
+            includedTargets: [{
+                "attribute": "url",
+                "inverted": "0",
+                "type": "equals_simple",
+                "value": "https:\/\/pilotage.inclusion.beta.gouv.fr\/"
+            }],
+            excludedTargets: [],
+            variations: [{
+                name: 'original',
+                activate: function(event) {
+                    original.classList.remove("d-none");
+                    variationB.classList.add('d-none');
+                }
+            }, {
+                name: 'VariationB', // you can also use '12' (ID of the variation) to hide the name
+                activate: function(event) {
+                    variationB.classList.remove("d-none");
+                    original.classList.add('d-none');
+                }
+            }],
+            trigger: function() {
+                return true; // here you can further customize which of your visitors will participate in this experiment
+            }
+        }]);
+    </script>
+    <!-- Matomo A/B Test -->
 {% endblock %}


### PR DESCRIPTION
## :thinking: Quoi ?

Il s’agit ici de vérifier quel design répond le mieux au parcours des utilisateurs et pour quelle version il y a plus de clics, de taux de conversion.

https://www.notion.so/gip-inclusion/38364e96fbd04756b0b22722e151cf9a?v=14306838403f4a82a081ed413838a1db&p=1d8fa0b6df09407d945b7a6d412887fe&pm=c

## :cake: Comment ? <!-- optionnel -->

Ajout d'un A/B Test Matomo pour 2/3semaines

## Pour tester
Sur le staging, en forcant la version affichée, a l'aide d'un parametre dans l'url
Version originale > https://pilotage-staging.cleverapps.io/?pk_ab_test=original
Version B > https://pilotage-staging.cleverapps.io/?pk_ab_test=VariationB
