### PR TITLE
Activer dependabot pour être tenu au courant des MAJ non-critique

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "requirement"
+      prefix-development: "dev requirement"
+    # Only allow updates to the lockfile for pip and
+    # ignore any version updates that affect the manifest
+    versioning-strategy: lockfile-only
+    # Allow up to 20 concurrent open PRs
+    open-pull-requests-limit: 20


### PR DESCRIPTION
## :thinking: Quoi ?

Plus d'info sur l'outil : https://docs.github.com/fr/code-security/getting-started/dependabot-quickstart-guide

Pour le moment il faudra repasser à la main sur les PR car `uv` n'est pas géré mais il y a une PR dans ce sens : https://github.com/dependabot/dependabot-core/pull/10040.
Mais en attendant ça aura au moins l'avantage de nous avertir qu'il y des MAJ à faire :).