### PR TITLE
Tableau de bord : Ajout d'un encart afin d’annoncer l’enquête utilisateurs

### DIFF
--- a/pilotage/templates/dashboards/tableau_de_bord_public.html
+++ b/pilotage/templates/dashboards/tableau_de_bord_public.html
@@ -48,12 +48,22 @@
                             </p>
                         </div>
                     {% else %}
-                        <div class="alert alert-warning mt-3 mt-md-4" role="status">
+                        <div class="alert alert-info alert-dismissible fade show mt-3 mt-md-4" role="status">
                             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
-                            <p class="mb-2">
-                                <strong>Modifications dans vos tableaux de bord !</strong>
-                            </p>
-                            <p class="mb-0">Des changements cet été sur vos tableaux de bord pour améliorer votre expérience et renforcer votre satisfaction, notamment l'ajout d'onglets thématiques.</p>
+                            <div class="row">
+                                <div class="col-auto pe-0">
+                                    <i class="ri-information-line ri-xl text-info" aria-hidden="true"></i>
+                                </div>
+                                <div class="col">
+                                    <p class="mb-2">
+                                        <strong>Enquête utilisateur : votre avis est précieux pour nous aider à améliorer nos tableaux de bord !</strong>
+                                    </p>
+                                    <p class="mb-0">Jusqu’au 20 octobre, prenez part à notre enquête sur l'usage des tableaux de bord dans vos missions et partagez vos suggestions d'amélioration.</p>
+                                </div>
+                                <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                                    <a class="btn btn-sm btn-primary btn-block btn-ico" href="https://tally.so/r/nPYGJd" target="_blank" rel="noopener"><span>Je participe à l’enquête</span> <i class="ri-external-link-line font-weight-medium" aria-hidden="true"></i></a>
+                                </div>
+                            </div>
                         </div>
                     {% endif %}
                 </div>


### PR DESCRIPTION
## :thinking: Quoi ?

https://www.notion.so/gip-inclusion/enqu-te-utilisateur-Ajouter-un-encart-sur-les-TDB-afin-d-annoncer-l-enqu-te-utilisateurs-6d9f60a98d7840ce9cc3d52ee1119cbd?pvs=4

## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/user-attachments/assets/6d25ab92-f800-4cfb-aa6a-ded76ee0428c)
