### PR TITLE
Tableaux de bord : Ajout d'une bannière pour le webinaire Q&R

### DIFF
--- a/pilotage/templates/dashboards/tableau_de_bord_public.html
+++ b/pilotage/templates/dashboards/tableau_de_bord_public.html
@@ -47,6 +47,27 @@
                                 Nous aimerions échanger avec quelques utilisateurs de ce nouveau tableau de bord pour collecter des retours sur son usage, ses points forts et ses points d’amélioration. Vous avez 30 minutes à nous accorder ? <a href="https://tally.so/r/3jL896">Je suis volontaire !</a>
                             </p>
                         </div>
+                    {% else %}
+                        <div class="alert alert-info alert-dismissible fade show" role="status">
+                            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+                            <div class="row">
+                                <div class="col-auto pe-0">
+                                    <i class="ri-information-line ri-xl text-info" aria-hidden="true"></i>
+                                </div>
+                                <div class="col">
+                                    <p class="mb-2">
+                                        <strong>Des questions sur l’utilisation des tableaux de bord ?</strong>
+                                    </p>
+                                    <p class="mb-0">Nous y répondons lors d’un webinaire questions / réponses animé chaque mois.</p>
+                                </div>
+                                <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                                    <a class="btn btn-sm btn-primary btn-block btn-ico"
+                                       href="https://app.livestorm.co/itou/le-pilotage-de-linclusion-professionnels-de-liae-questions-reponses-sur-les-tableaux-de-bord-1"
+                                       target="_blank"
+                                       rel="noopener"><span>Je m’inscris</span> <i class="ri-external-link-line fw-medium" aria-hidden="true"></i></a>
+                                </div>
+                            </div>
+                        </div>
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
## :thinking: Quoi ?

https://www.notion.so/gip-inclusion/Encart-Ajouter-un-encart-sur-la-page-des-TB-priv-s-et-publics-1455f321b60480a5a091f8d0abea988f?pvs=4

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/user-attachments/assets/70055dd6-42d6-4e50-accd-64083ca6a09b)
