### PR TITLE
Tableaux de bord : Désactiver l’encart webinaires

### DIFF
--- a/pilotage/dashboards/views.py
+++ b/pilotage/dashboards/views.py
@@ -22,5 +22,5 @@ def tableau_de_bord_public(request, slug):
     return render(
         request,
         "dashboards/tableau_de_bord_public.html",
-        context={"dashboard": dashboard, "slug": slug},
+        context={"dashboard": dashboard, "slug": slug, "show_webinar_banner": False},
     )

--- a/pilotage/templates/dashboards/tableau_de_bord_public.html
+++ b/pilotage/templates/dashboards/tableau_de_bord_public.html
@@ -47,7 +47,7 @@
                                 Nous aimerions échanger avec quelques utilisateurs de ce nouveau tableau de bord pour collecter des retours sur son usage, ses points forts et ses points d’amélioration. Vous avez 30 minutes à nous accorder ? <a href="https://tally.so/r/3jL896">Je suis volontaire !</a>
                             </p>
                         </div>
-                    {% else %}
+                    {% elif show_webinar_banner %}
                         <div class="alert alert-info alert-dismissible fade show" role="status">
                             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
                             <div class="row">


### PR DESCRIPTION
## :thinking: Quoi ?

Il n'y a plus des webinaires prévues (https://www.notion.so/gip-inclusion/Supprimer-l-encart-webinaires-q-r-1775f321b60480bb906afda8030656ce).
