### PR TITLE
github : Mise en place de l'app "MiseEnProd" pour le dépôt

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -1,0 +1,25 @@
+name: 📢 Notify Slack of changed PR
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  notify:
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
+    if: >
+      github.event.pull_request.merged == true
+      && !contains(github.event.pull_request.labels.*.name, 'dependencies')
+    runs-on: ubuntu-latest
+    steps:
+      - name: "📢 Notify the #mep-c2 channel"
+        # Can't use `!contains(...)` because it give us a "tag suffix cannot contain flow indicator characters" error.
+        # Oddly enough, using `if: > !contains(...)` works...
+        if: contains(github.event.pull_request.labels.*.name, 'no-changelog') == false
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_MEP_C2_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: >-
+              [${{ github.event.pull_request.base.label }}] ${{ format('<{0}|{1}>', github.event.pull_request.html_url, github.event.pull_request.title) }}

--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -1,0 +1,16 @@
+name: Label Checks
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, merge_group]
+
+jobs:
+  require-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify changelog label
+        uses: mheap/github-action-required-labels@5.5.0
+        with:
+          mode: exactly
+          count: 1
+          labels: "ajouté, modifié, supprimé, tech, dependencies, no-changelog"


### PR DESCRIPTION
## :thinking: Quoi ?

Afin d'avoir un petit message lors de la fusion d'une PR.
Pour le moment on "mentira" car le message apparaîtra à la fusion d'une PR dans `staging` et pas dans `main` mais c'est déjà mieux que rien je pense :), et si on se débarrasse de `staging` alors plus de problème !