### PR TITLE
Passage à python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     - name: 💂 Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
         cache: pip
         cache-dependency-path: requirements/dev.txt
     - name: 📥 Install Python dependencies

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # > practice; so for compatibility, you must explicitly request it
 .DELETE_ON_ERROR:
 
-PYTHON_VERSION := python3.12
+PYTHON_VERSION := python3.13
 REQUIREMENTS_PATH ?= requirements/dev.txt
 
 VIRTUAL_ENV ?= .venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 
 [tool.ruff]
 line-length = 119


### PR DESCRIPTION

## :thinking: Quoi ?

`CC_PYTHON_VERSION` était configuré à `3` donc on est passé en 3.13 automatiquement, je viens de modifier la variable d'environnement (_prod_ et _staging_) en `3.13` afin de ne pas refaire la même erreur pour la 3.14.
