### PR TITLE
Configuration : Activer `GZipMiddleware` and `ConditionalGetMiddleware` pour améliorer le temps de réponse HTTP

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -68,7 +68,9 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "django.middleware.gzip.GZipMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.http.ConditionalGetMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",


### PR DESCRIPTION
## :thinking: Quoi ?

La site est composé quasi-exclusivement de page statique donc `ConditionalGetMiddleware` à un intérêt pour nous, et il va aussi servir pour la futur API afin d'améliorer l'expérience utilisateur coté frontend.
Et aucune raison de ne pas activer `GZipMiddleware`, les données que l'on renvois se compresse très bien, ce qui est aussi un avantage pour la futur API ;).