### PR TITLE
Configuration CORS pour l'API

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -63,6 +63,7 @@ INSTALLED_APPS = [
     "pilotage.dashboards",
     "pilotage.utils",
     "compressor",
+    "corsheaders",
 ]
 
 MIDDLEWARE = [
@@ -70,6 +71,7 @@ MIDDLEWARE = [
     "django_datadog_logger.middleware.request_id.RequestIdMiddleware",
     # Django stack
     "django.middleware.security.SecurityMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.gzip.GZipMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.http.ConditionalGetMiddleware",
@@ -211,6 +213,10 @@ sentry_sdk.init(
     traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.1")),
 )  # Read from SENTRY_DSN and SENTRY_ENVIRONMENT
 ignore_logger("django.security.DisallowedHost")
+
+# CORS
+CORS_URLS_REGEX = r"^/api/.*$"
+CORS_ALLOW_ALL_ORIGINS = True
 
 # Project settings
 # ----------------

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,6 +5,7 @@ psycopg[binary]  # https://github.com/psycopg/psycopg
 
 Django==5.1.*  # https://www.djangoproject.com/
 django-compressor  # https://django-compressor.readthedocs.io/en/latest/
+django-cors-headers  # https://github.com/adamchainz/django-cors-headers
 django-datadog-logger  # https://github.com/namespace-ee/django-datadog-logger
 django-libsass  # https://github.com/torchbox/django-libsass
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,9 @@ anyio==4.9.0 \
 asgiref==3.8.1 \
     --hash=sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47 \
     --hash=sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590
-    # via django
+    # via
+    #   django
+    #   django-cors-headers
 certifi==2025.1.31 \
     --hash=sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651 \
     --hash=sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe
@@ -22,6 +24,7 @@ django==5.1.7 \
     #   -r requirements/base.in
     #   django-appconf
     #   django-compressor
+    #   django-cors-headers
     #   django-datadog-logger
     #   djangorestframework
 django-appconf==1.1.0 \
@@ -34,6 +37,10 @@ django-compressor==4.5.1 \
     # via
     #   -r requirements/base.in
     #   django-libsass
+django-cors-headers==4.7.0 \
+    --hash=sha256:6fdf31bf9c6d6448ba09ef57157db2268d515d94fc5c89a0a1028e1fc03ee52b \
+    --hash=sha256:f1c125dcd58479fe7a67fe2499c16ee38b81b397463cf025f0e2c42937421070
+    # via -r requirements/base.in
 django-datadog-logger==0.7.3 \
     --hash=sha256:4361bb068a4b188fa14135398f9b747728464a291757e6adf8c95c9215dcd602 \
     --hash=sha256:87838cd868f407e050831c536413de6b2ece31433b28c952c0fd90be1d66486a

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,6 +12,7 @@ asgiref==3.8.1 \
     # via
     #   -r requirements/test.txt
     #   django
+    #   django-cors-headers
 beautifulsoup4==4.13.3 \
     --hash=sha256:1bd32405dacc920b42b83ba01644747ed77456a65760e285fbc47633ceddaf8b \
     --hash=sha256:99045d7d3f08f91f0d656bc9b7efbae189426cd913d830294a15eefa0ea4df16
@@ -49,6 +50,7 @@ django==5.1.7 \
     #   -r requirements/test.txt
     #   django-appconf
     #   django-compressor
+    #   django-cors-headers
     #   django-datadog-logger
     #   django-debug-toolbar
     #   djangorestframework
@@ -64,6 +66,10 @@ django-compressor==4.5.1 \
     # via
     #   -r requirements/test.txt
     #   django-libsass
+django-cors-headers==4.7.0 \
+    --hash=sha256:6fdf31bf9c6d6448ba09ef57157db2268d515d94fc5c89a0a1028e1fc03ee52b \
+    --hash=sha256:f1c125dcd58479fe7a67fe2499c16ee38b81b397463cf025f0e2c42937421070
+    # via -r requirements/test.txt
 django-datadog-logger==0.7.3 \
     --hash=sha256:4361bb068a4b188fa14135398f9b747728464a291757e6adf8c95c9215dcd602 \
     --hash=sha256:87838cd868f407e050831c536413de6b2ece31433b28c952c0fd90be1d66486a

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,6 +12,7 @@ asgiref==3.8.1 \
     # via
     #   -r requirements/base.txt
     #   django
+    #   django-cors-headers
 beautifulsoup4==4.13.3 \
     --hash=sha256:1bd32405dacc920b42b83ba01644747ed77456a65760e285fbc47633ceddaf8b \
     --hash=sha256:99045d7d3f08f91f0d656bc9b7efbae189426cd913d830294a15eefa0ea4df16
@@ -43,6 +44,7 @@ django==5.1.7 \
     #   -r requirements/base.txt
     #   django-appconf
     #   django-compressor
+    #   django-cors-headers
     #   django-datadog-logger
     #   djangorestframework
 django-appconf==1.1.0 \
@@ -57,6 +59,10 @@ django-compressor==4.5.1 \
     # via
     #   -r requirements/base.txt
     #   django-libsass
+django-cors-headers==4.7.0 \
+    --hash=sha256:6fdf31bf9c6d6448ba09ef57157db2268d515d94fc5c89a0a1028e1fc03ee52b \
+    --hash=sha256:f1c125dcd58479fe7a67fe2499c16ee38b81b397463cf025f0e2c42937421070
+    # via -r requirements/base.txt
 django-datadog-logger==0.7.3 \
     --hash=sha256:4361bb068a4b188fa14135398f9b747728464a291757e6adf8c95c9215dcd602 \
     --hash=sha256:87838cd868f407e050831c536413de6b2ece31433b28c952c0fd90be1d66486a


### PR DESCRIPTION
## :thinking: Quoi ?

On autorise n'importe quelle origine mais seulement pour les URL commençant par `/api/`.

Testé en local avec https://github.com/gip-inclusion/offre-inclusion