### PR TITLE
Correction du tag Matomo pour le suivi des visiteurs

### DIFF
--- a/pilotage/templates/partials/footer-scripts.html
+++ b/pilotage/templates/partials/footer-scripts.html
@@ -72,7 +72,7 @@
 {% if MATOMO_BASE_URL and MATOMO_SITE_ID %}
     <script>
         tarteaucitron.user.matomoId = "{{ MATOMO_SITE_ID }}";
-        tarteaucitron.user.matomoHost = "{{ MATOMO_BASE_URL }}";
+        tarteaucitron.user.matomoHost = "{{ MATOMO_BASE_URL }}/";
         (tarteaucitron.job = tarteaucitron.job || []).push('matomo');
     </script>
 


### PR DESCRIPTION
## :thinking: Quoi ?

Les visites ne sont plus comptabilisée depuis 535619b145ab7118839bfa894b7ac3062f31d7d9.