### PR TITLE
Études ESAT : Correction d'une valeur manquante pour le nombre d'heures de soutien

### DIFF
--- a/pilotage/surveys/migrations/0001_initial.py
+++ b/pilotage/surveys/migrations/0001_initial.py
@@ -966,6 +966,7 @@ class Migration(migrations.Migration):
                         blank=True,
                         choices=[
                             ("LESS_THAN_50", "Moins de 50 heures"),
+                            ("RANGE_50_100", "Entre 50 et 100 heures"),
                             ("RANGE_100_150", "Entre 100 et 150 heures"),
                             ("RANGE_150_200", "Entre 150 et 200 heures"),
                             ("RANGE_200_250", "Entre 200 et 250 heures"),

--- a/pilotage/surveys/models.py
+++ b/pilotage/surveys/models.py
@@ -127,6 +127,7 @@ class DocumentFALCList(TextChoices):
 
 class SupportHoursRange(TextChoices):
     LESS_THAN_50 = "LESS_THAN_50", "Moins de 50 heures"
+    RANGE_50_100 = "RANGE_50_100", "Entre 50 et 100 heures"
     RANGE_100_150 = "RANGE_100_150", "Entre 100 et 150 heures"
     RANGE_150_200 = "RANGE_150_200", "Entre 150 et 200 heures"
     RANGE_200_250 = "RANGE_200_250", "Entre 200 et 250 heures"


### PR DESCRIPTION
## :thinking: Quoi ?

Il manquais la tranche 50-100 pour `nb_support_hours`
